### PR TITLE
Adding printf() functionality into FX2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 docs/html
 build
 *_str.c
+*~
+*.hex

--- a/examples/fast_uart/Makefile
+++ b/examples/fast_uart/Makefile
@@ -1,0 +1,6 @@
+FX2LIBDIR=../..
+BASENAME = uart_main
+SOURCES=uart_main.c
+DSCR_AREA=
+INT2JT=
+include $(FX2LIBDIR)/lib/fx2.mk

--- a/examples/fast_uart/README.md
+++ b/examples/fast_uart/README.md
@@ -1,0 +1,17 @@
+- git clone https://github.com/RacingTornado/fx2lib
+- cd fx2lib
+- make
+- For fast_uart , git checkout fast_uart
+- make
+- cd examples/fast_uart
+- make
+- ./download.sh build/uart_main.ihx
+
+By default a fast_uart(0x30) is inserted in the main while loop. You need to open up a console, I use
+
+sudo minicom -H -w fastuart
+
+You should have the parameters of fastuart set to 115200. You should see the values on the terminal.
+
+The PA2 pin must be connected to the rx pin on the serial adaptor.
+	

--- a/examples/fast_uart/download.sh
+++ b/examples/fast_uart/download.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+DEVS=$(lsusb|grep -E '(2a19|16c0|04b4|1d50|fb9a|1443)' |sed 's/:.*//;s/Bus //;s/Device //;s/ /\//')
+
+if [ -z "$1" ]; then
+    echo "$0: usage: $0 <file>"
+    exit 1;
+fi
+
+for dev in $DEVS;do
+    echo "Downloading $1 to $dev"
+    /sbin/fxload -D /dev/bus/usb/$dev -t fx2lp -I $1
+done
+
+exit 0

--- a/examples/fast_uart/uart_main.c
+++ b/examples/fast_uart/uart_main.c
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2009 Ubixum, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ **/
+#include <fx2regs.h>
+#include <delay.h>
+#include <stdio.h>
+#include <softuart.h>
+void main(void)
+{
+    uart0_init();
+    while (TRUE)
+   {
+      printf("Hello");
+   }
+}
+
+void putchar(char c)
+{
+    uart0_transmit(c);
+}

--- a/include/softuart.h
+++ b/include/softuart.h
@@ -1,0 +1,94 @@
+/** \file softuart.h
+ * Utilities for reading and writing to UART devices.
+ * Defines top level functions which the printf and scanf access. 
+ * The implementation of these functions vary depending on whether 
+ * fast_uart is being used or timer based UART is being used. This 
+ * is configurable depending on the way uart0_init() is called
+ **/
+
+#ifndef FX2_UART
+#define FX2_UART
+
+#include "fx2types.h"
+
+/**
+ * \brief initalizes UART.
+ * This function uart0_init accepts the baud_rate and the mask. The mask 
+ * indicates where the UART_TX pin must be attached. The rx_mask performs a 
+ * similar function. The function will then use a case statement to identify 
+ * the correct location and then do a .equ TX_PIN to define the transmit pin. 
+ *   Possible Baud rates:(fast_uart)
+ *    \li 2400
+ *    \li 4800
+ *    \li 9600
+ *    \li 19200
+ *    \li 28800
+ *    \li 38400
+ *    \li 57600
+ *    \li 115200
+ *    This function sets the CPUCS to 48Mhz . It then uses assembly to 
+ *    delay the pin timing to get the required baud rate with the necessary
+ *    accuracy or initializes and starts a timer depending on the situation. 
+ *    This function will map to a timer based delay function 
+ *    in case of a the timer based uart. The only restriction is that this 
+ *    function will not be able to have a baud rate of a value greater 
+ *    than 9600 , if an ISR is used to shift the data out. This is because 
+ *    the UART RX logic should run much faster than the TX logic to
+ *    detect the start bit. A decision to have the same UART TX/RX rates 
+ *    was chosen. Thus the allowable baud rates for this function is
+ *   Possible Baud rates:(timer based uart)
+ *    \li 2400
+ *    \li 4800
+ *    \li 9600
+ * \param rate enum for baud_rate
+ * \param type enum for selecting what type of UART is actually used
+ * \param tx_pin The pin to which the UART_TX routine must be attached
+ * \param rx_pin The pin to which the UART_RX routine must be attached
+ **/
+void uart0_init (enum uart_baud rate, enum uart_type type, enum pins_fx2 tx_pin, enum pins_fx2 rx_pin) __critical;
+
+/**
+ * \brief transmits data through UART.
+ * The uart0_transmit maps to different functions depending on the underlying
+ * mechanism which is used to transmit the byte. In the case of bitbanging UART
+ * without timers, it becomes blocking.  If timer based UART is used, then 
+ * it is non blocking. It puts the data into the queue and returns without 
+ * doing anything else. The ISR then handles the shifting of the data out.  
+ * Be careful regarding queue overflows when using non-blocking UART,  
+ * that is make sure there is enough time between calls to printf.
+ * \param c character to be written to UART
+**/
+void uart0_transmit (char c);
+
+/**
+ * \brief receives data through UART.
+ * This function uart0_receive is basically empty for fast_uart. However, in case of  
+ * timer based UART. It reads data from the queue, and returns a single character which 
+ * can then be used by the calling program.
+ *
+**/
+char uart0_receive ();
+
+/**
+ * enum used for easy access for baud rate selection.
+ *
+**/
+enum uart_baud { U_2400, U_4800, U_9600, U_19200, U_38400, U_57600, U_115200 };
+/**
+ * Defines the type of UART which is used to send out the bits. If FAST_UART is used , high baud
+ * rates can be achieved. However, only transmit functionality will be supported, and the function
+ * call will block. TIMER_UART on the other hand uses a Queue(based on buffers) and does not block.
+ * It allows both transmit and receive functionality , however the baud rates supported are much slower.
+ *
+**/
+enum uart_type { FAST_UART , TIMER_UART };
+/**
+ * enum used for easy access to fx2 pins
+ *
+**/
+enum pins_fx2 { PA_0,PA_1,PA_2,PA_3,PA_4,PA_5,PA_6,PA_7,
+		PB_0,PB_1,PB_2,PB_3,PB_4,PB_5,PB_6,PB_7,
+		PD_0,PD_1,PD_2,PD_3,PD_4,PD_5,PD_6,PD_7
+ };
+
+#endif

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,7 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 AS8051?=sdas8051
-SOURCES = serial.c i2c.c delay.c setupdat.c gpif.c eputils.c $(wildcard interrupts/*.c)
+SOURCES = serial.c i2c.c delay.c setupdat.c gpif.c eputils.c softuart.c $(wildcard interrupts/*.c)
 FX2_OBJS = $(patsubst %.c,%.rel, $(SOURCES)) usbav.rel
 INCLUDES = -I../include
 SDCC = sdcc -mmcs51 $(SDCCFLAGS)

--- a/lib/softuart.c
+++ b/lib/softuart.c
@@ -1,0 +1,77 @@
+/*
+Remarks By Roaring(for the FX2LP from cypress)
+*/
+
+#include <fx2regs.h>
+#include <fx2macros.h>
+#include <serial.h>
+
+
+
+void uart0_init()
+{
+    SETCPUFREQ(CLK_48M);
+}
+
+
+void uart0_transmit(char c)
+{
+    //Done in ASM to improve performance. It takes only 6
+    //cycles to move the data out, however a delay has been
+    //introduced in order to get a baud rate of 115200
+    //The mask which is to be written into the pin
+    OEA |= 0x04;
+    //An efficient UART bitbang routine in assembly
+    __asm
+    //Like #define in C. Can easily be used to change the pin
+    .equ _TX_PIN, _PA2
+    //Disable interrupts
+    //This is used because timing is critical
+    //If the FX2 jumps into the ISR temporarily , it may cause transmit
+    //errors. By clearing EA, we can disable interrupts
+    clr _EA //(2 cycles)
+    //Move the data to be sent into the ACC
+    //The data which is to be shifted out is held in the dpl register
+    //We move the data into A for easy access to subsequent instructions
+    mov a , dpl //(2 cyles)
+    clr c //(1 cycle)
+    //We need to send out 8 bits of data
+    //Load r0 with value 8
+    mov r0, #0x08 //(2 cycles)
+    //Create the start bit
+    clr _TX_PIN  //(2 cycles)
+    //Precalculated delay since 1 cycle takes 88ns
+    //At 12Mhz, it should be about 83.33ns
+    //But it appears to be about 88ns
+    //These numbers have been verified using an analyzer
+    mov r1, #0x20 //(2 cycles)
+    0006$:
+    //1 bit is about 8.6us
+    djnz r1, 0006$ //DJNZ on Rn takes (3 cycles)
+    //NOP takes about 1 cycle
+    //Add 2 more cycles of delay
+    //97 cycles
+    nop //(1 cycle)
+    nop //(1 cycle)
+    0001$:
+    rrc a // (2 cycles). This rotates the accumulator right through the carry
+    //Move the carry into the port
+    mov _TX_PIN, c //(2 cycles)
+    //Now we need to add delay for the next
+    mov r1, #0x1F //(2 cycles) 
+    //31*3 , 93 cycles of delay
+    0004$:
+    djnz r1, 0004$ //(3 cycles)
+    nop  //(1 cycle)
+    //3 more cycles of delay
+    //97 cycles
+    djnz r0, 0001$ //(3 cycles)
+    setb _TX_PIN  //(2 cycles) This is for stop bit
+    //We need to delay the stop bit,  otherwise we may get errors.
+    mov r1, #0x20 //(2 cycles)
+    0005$:
+    djnz r1, 0005$ //(3 cycles) for DJNZ , Jump for 32*3 , 96 cycles 
+    nop //(NOP takes 1 cycle) 97 cycles of delay
+    setb _EA; //Enable back the interrupts
+    __endasm;
+}


### PR DESCRIPTION
- git clone https://github.com/RacingTornado/fx2lib
- cd fx2lib
- make
  For fast_uart , git checkout branch_name
- make
- cd examples/fast_uart
- make
- ./download.sh build/uart_main.ihx

sudo minicom -H -w fastuart

You should have the parameters of fastuart set to 115200. You should see the values on the terminal.

The PA2 pin must be connected to the rx pin on the serial adaptor. In this situation , the ground must be the same also. Else you may get receiving errors. 

The idea is to use this for debugging purposes. The baud rates is set to 115200 by setting the delay values. 

Another important fact is that the console must be first opened up before loading the firmware onto the FX2. This is required for getting a lock on the start and the stop bits since there is no line break attached between the 2 bytes. 

Code has been cleaned up and the firmware in the examples directory is extremely small(less than 5-6 lines)
Assembly has been extensively commented.
The .gitignore files have not been brought back because of the issue discussed in the email. I would like to merge this with the linux-descriptors branch since this is what I used as a base
