### PR TITLE
Created a buffer API definition in buffer/api.h to allow access to FX2 buffers using a standard manner

### DIFF
--- a/examples/buffers/Makefile
+++ b/examples/buffers/Makefile
@@ -1,0 +1,10 @@
+FX2LIBDIR=../..
+BASENAME = buffers
+SOURCES=buffers.c
+DSCR_AREA=
+INT2JT=
+include $(FX2LIBDIR)/lib/fx2.mk
+fx2_download:
+	../download.sh build/$(BASENAME).ihx
+
+

--- a/examples/buffers/buffers.c
+++ b/examples/buffers/buffers.c
@@ -21,18 +21,24 @@
 #include <lights.h>
 #include <delay.h>
 #include <buffer/buffer.h>
+#include <stdio.h>
 
-CREATE_BUFFER_AUTOPTR_SINGLE(uart0,5)
+CREATE_BUFFER_AUTOPTR_SINGLE(buffer0,5)
 
-
+void uart0_tx(char data);
 void main(void)
 {
-	//buffer0_init();
+	buffer0_init();
 	SETCPUFREQ(CLK_48M);
 	// loop endlessly
 	for(;;) {
-		//buffer0_push(0x44);
-		//uart0_tx(buffer0_pop());
+		buffer0_push(0x44);
+		printf("HeaderWrite MSB %02x \r\n",buffer0_head_MSB);
+		printf("HeaderWrite LSB %02x \r\n",buffer0_head_LSB);
+		printf("Buffer is at %p \r\n",buffer0_buffer);
+		printf("HeaderRead MSB %02x \r\n",buffer0_tail_MSB);
+		printf("HeaderRead LSB %02x \r\n",buffer0_tail_LSB);
+		printf("Data is %02x\r\n",buffer0_pop());
 	    }
 }
 
@@ -98,6 +104,10 @@ void uart0_tx(char c)
     __endasm;
 }
 
+void putchar(char c)
+{
+uart0_tx(c);
+}
 
 
 

--- a/examples/buffers/buffers.c
+++ b/examples/buffers/buffers.c
@@ -24,7 +24,7 @@
 #include <stdio.h>
 
 CREATE_BUFFER_AUTOPTR_SINGLE(buffer0,5)
-
+__xdata BYTE data_buffer[10];
 void uart0_tx(char data);
 void main(void)
 {

--- a/examples/buffers/buffers.c
+++ b/examples/buffers/buffers.c
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2009 Ubixum, Inc. 
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ **/
+
+#include <fx2regs.h>
+
+#include <lights.h>
+#include <delay.h>
+#include <buffer/buffer.h>
+
+CREATE_BUFFER_AUTOPTR_SINGLE(uart0,5)
+
+
+void main(void)
+{
+	//buffer0_init();
+	SETCPUFREQ(CLK_48M);
+	// loop endlessly
+	for(;;) {
+		//buffer0_push(0x44);
+		//uart0_tx(buffer0_pop());
+	    }
+}
+
+void uart0_tx(char c)
+{
+    //Done in ASM to improve performance. It takes only 6
+    //cycles to move the data out, however a delay has been
+    //introduced in order to get a baud rate of 115200
+    //The mask which is to be written into the pin
+    OEA |= 0x04;
+    //An efficient UART bitbang routine in assembly
+    __asm
+    //Like #define in C. Can easily be used to change the pin
+    .equ _TX_PIN, _PA2
+    //Disable interrupts
+    //This is used because timing is critical
+    //If the FX2 jumps into the ISR temporarily , it may cause transmit
+    //errors. By clearing EA, we can disable interrupts
+    clr _EA //(2 cycles)
+    //Move the data to be sent into the ACC
+    //The data which is to be shifted out is held in the dpl register
+    //We move the data into A for easy access to subsequent instructions
+    mov a , dpl //(2 cyles)
+    clr c //(1 cycle)
+    //We need to send out 8 bits of data
+    //Load r0 with value 8
+    mov r0, #0x08 //(2 cycles)
+    //Create the start bit
+    clr _TX_PIN  //(2 cycles)
+    //Precalculated delay since 1 cycle takes 88ns
+    //At 12Mhz, it should be about 83.33ns
+    //But it appears to be about 88ns
+    //These numbers have been verified using an analyzer
+    mov r1, #0x20 //(2 cycles)
+    0006$:
+    //1 bit is about 8.6us
+    djnz r1, 0006$ //DJNZ on Rn takes (3 cycles)
+    //NOP takes about 1 cycle
+    //Add 2 more cycles of delay
+    //97 cycles
+    nop //(1 cycle)
+    nop //(1 cycle)
+    0001$:
+    rrc a // (2 cycles). This rotates the accumulator right through the carry
+    //Move the carry into the port
+    mov _TX_PIN, c //(2 cycles)
+    //Now we need to add delay for the next
+    mov r1, #0x1F //(2 cycles) 
+    //31*3 , 93 cycles of delay
+    0004$:
+    djnz r1, 0004$ //(3 cycles)
+    nop  //(1 cycle)
+    //3 more cycles of delay
+    //97 cycles
+    djnz r0, 0001$ //(3 cycles)
+    setb _TX_PIN  //(2 cycles) This is for stop bit
+    //We need to delay the stop bit,  otherwise we may get errors.
+    mov r1, #0x20 //(2 cycles)
+    0005$:
+    djnz r1, 0005$ //(3 cycles) for DJNZ , Jump for 32*3 , 96 cycles 
+    nop //(NOP takes 1 cycle) 97 cycles of delay
+    setb _EA; //Enable back the interrupts
+    __endasm;
+}
+
+
+
+
+
+
+
+
+
+

--- a/examples/buffers/buffers.c
+++ b/examples/buffers/buffers.c
@@ -33,11 +33,11 @@ void main(void)
 	// loop endlessly
 	for(;;) {
 		buffer0_push(0x44);
-		printf("HeaderWrite MSB %02x \r\n",buffer0_head_MSB);
-		printf("HeaderWrite LSB %02x \r\n",buffer0_head_LSB);
+		printf("HeaderWrite MSB %02x \r\n",head_MSB);
+		printf("HeaderWrite LSB %02x \r\n",head_LSB);
 		printf("Buffer is at %p \r\n",buffer0_buffer);
-		printf("HeaderRead MSB %02x \r\n",buffer0_tail_MSB);
-		printf("HeaderRead LSB %02x \r\n",buffer0_tail_LSB);
+		printf("HeaderRead MSB %02x \r\n",tail_MSB);
+		printf("HeaderRead LSB %02x \r\n",tail_LSB);
 		printf("Data is %02x\r\n",buffer0_pop());
 	    }
 }

--- a/examples/download.sh
+++ b/examples/download.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+DEVS=$(lsusb|grep -E '(2a19|16c0|04b4|1d50|fb9a|1443)' |sed 's/:.*//;s/Bus //;s/Device //;s/ /\//')
+
+if [ -z "$1" ]; then
+    echo "$0: usage: $0 <file>"
+    exit 1;
+fi
+
+for dev in $DEVS;do
+    echo "Downloading $1 to $dev"
+    /sbin/fxload -D /dev/bus/usb/$dev -t fx2lp -I $1
+done
+
+exit 0

--- a/include/buffer/api.h
+++ b/include/buffer/api.h
@@ -1,0 +1,106 @@
+/** \file include/buffer/api.h
+ * Used for defining a common API for accessing buffers on the FX2.
+ **/
+
+#ifndef BUFFER_API_H
+#define BUFFER_API_H
+#include "fx2types.h"
+
+/**
+ * \brief Initializes a buffer.
+ **/
+BOOL bufferX_init();
+
+/**
+ * \brief Gets the next byte from the UART buffer if the buffer is not empty.
+**/
+BYTE bufferX_pop();
+
+/**
+ * \brief Inserts a byte into the buffer if not full.
+ * Returns if the byte was inserted or not.
+ * TRUE  - The data has been inserted into the buffer.
+ * FALSE - Buffer is full. Byte has not been inserted.
+**/
+BOOL bufferX_push(BYTE data);
+
+/**
+ * \brief  Returns if the buffer is full or not.
+ * TRUE   - Buffer is full.
+ * FALSE  - Buffer is not full.
+**/
+BOOL bufferX_is_full();
+
+/**
+ * \brief  Returns if the buffer is empty or not.
+ * TRUE   - Buffer is empty.
+ * FALSE  - Buffer is not empty.
+**/
+BOOL bufferX_is_empty();
+
+/**
+ * \brief Returns the number of bytes which can be inserted into the buffer.
+**/
+BYTE bufferX_bytes_left();
+
+/**
+ * \brief Removes all the elements in the buffer. Flushes the entire buffer.
+**/
+BYTE bufferX_flush();
+
+/**
+ * \brief Returns the maximum size of the buffer. WARNING:(This is always less than 256 bytes).
+**/
+BYTE bufferX_max_size();
+
+/**
+ * \brief This function directly inserts the data into the current address of the buffer.
+ * WARNING: This function will overwrite the data in the current address location.
+ * \param BYTE data The data to be inserted into the buffer.
+ * Returns if the data has been added in the buffer or not.
+ * TRUE   - Data has been added.
+ * FALSE  - An error occured. The data has not been added to the buffer.
+**/
+BOOL bufferX_insert_byte(BYTE data);
+
+/**
+ * \brief Returns the data at the current address pointed to, by the buffer without
+ * changing the address pointer. The data will still exist in the buffer.
+ * \param offset The number of locations the address pointer needs to be decremented in order
+ * to get access to the data.
+**/
+BYTE bufferX_peek(BYTE offset);
+
+/**
+ * \brief Increments the address which is being pointed to by the buffer.
+ * WARNING: This function will cause the address to be incremented by 1.
+ * This will cause you to skip over data if the current address holds data which 
+ * you would like to access.
+ * Returns if the address has been incremented or not.
+ * TRUE   - The address has been incremented.
+ * FALSE  - An error occured. The address could not be incremented.
+**/
+BOOL bufferX_inc();
+
+/**
+ * \brief Decrements the address which is being pointed to by the buffer.
+ * WARNING: This function will cause the address to be decremented by 1.
+ * This will cause you to skip over data if the current address holds data which 
+ * you would like to access.(This function is equivalent to a pop without returning
+ * the data which has been removed).
+ * Returns if the address has been decremented or not.
+ * TRUE   - The address has been decremented.
+ * FALSE  - An error occured. The address could not be decremented.
+**/
+BOOL bufferX_dec();
+
+/**
+ * \brief  Copies the source bytes into the destination bytes.
+ * \param src The source address location.
+ * \param dst The destination address into which the data has been copied.
+ * \param size The number of bytes which need to be copied from the source address
+ * into the destination address.
+**/
+BYTE bufferX_copy_bytes(__xdata BYTE *src,__xdata BYTE *dst,BYTE size);
+
+#endif

--- a/include/buffer/buffer.h
+++ b/include/buffer/buffer.h
@@ -17,6 +17,11 @@ BYTE buffer_number;
  **/
 BYTE current_buffer;
 
+/**
+ * \brief Stores the current data. The data in the DPL is often over written because of the DPTR functions.
+ **/
+BYTE store_data;
+
 
 
 __sfr __at 0x9a   head_MSB;
@@ -84,7 +89,7 @@ __sfr __at 0x9e   tail_LSB;
 		mov _head_MSB,_##name##src				\
 		mov _head_LSB,_##name##_offset			\
 		__endasm;								\
-											\
+		put_data();					\
 	}										\
 	BYTE name##_pop()								\
 	{										\
@@ -98,11 +103,12 @@ static inline void put_data()
 {
 	/*The first thing to do is check whether we need to reload the address pointer
 	 *This handles the buffer_switch logic. That is a new buffer is being opened.	
-	*/	
-	__asm				
-	mov	dptr,#_XAUTODAT1		;(Read data now)		
-	mov	a,#0x35				;(push the data into the ACC)	
-	movx	@dptr,a				;(Move the data back)	
+	*/
+	__asm
+	mov _store_data,dpl		
+	mov	dptr,#_XAUTODAT1			;(Read data now)		
+	mov	a,_store_data				;(push the data into the ACC)	
+	movx	@dptr,a					;(Move the data back)	
 	__endasm;				
 }
 

--- a/include/buffer/buffer.h
+++ b/include/buffer/buffer.h
@@ -55,7 +55,8 @@ static inline void get_data()
 static inline BYTE return_data()
 {
 	__asm
-	mov dptr,#0x3c00
+	mov dph,_buffer0_tail_MSB
+	mov dpl,_buffer0_tail_LSB
 	movx a,@dptr
 	mov dpl,a
 	__endasm;

--- a/include/buffer/buffer.h
+++ b/include/buffer/buffer.h
@@ -37,7 +37,7 @@
 	}										\
 	BOOL name##_push(BYTE data)							\
 	{										\
-		get_data();								\
+		put_data();								\
 	}										\
 	BYTE name##_pop()								\
 	{										\
@@ -47,17 +47,17 @@
 	BOOL name##_push(BYTE data);							\
 	BYTE name##_pop();
 
-static inline void get_data()
+static inline void put_data()
 {
-	XAUTODAT1 = 0x45;
+	XAUTODAT1 = 0x45; 						//(6 cycles totally)
 }
 
 static inline BYTE return_data()
 {
 	__asm
-	mov	dptr,#_XAUTODAT2
-	movx	a,@dptr
-	mov dpl,a
+	mov	dptr,#_XAUTODAT2					//(3 cycles)
+	movx	a,@dptr							//(1 cycle)
+	mov dpl,a							//(2 cycles)
 	__endasm;
 }		
 #endif

--- a/include/buffer/buffer.h
+++ b/include/buffer/buffer.h
@@ -1,0 +1,67 @@
+/** \file include/buffer/buffer.h
+ * Used for implementing the common API for accessing buffers on the FX2.
+ **/
+#ifndef BUFFER_BUFFER_H
+#define BUFFER_BUFFER_H
+#include "fx2types.h"
+#include <fx2macros.h>
+
+
+/**
+ * \brief Creates a buffer.
+ * \li name##_head - This is a single byte which stores the  location of the head pointer. 
+ * \li name##_tail - This is a single byte which stores the  location of the tail pointer.
+ * \li name##_size - The size of the buffer.
+ * \li name##_buffer - The actual buffer.
+ **/
+#define CREATE_BUFFER(name, type, size) \
+	volatile BYTE name##_head; \
+	volatile __bit name##_head_inc; \
+	volatile BYTE name##_tail; \
+	type BYTE name##_buffer[1<<size];
+
+#define CREATE_BUFFER_AUTOPTR_SINGLE(name,size) 					\
+	__sfr __at 0x9a volatile BYTE ##name_head_MSB; 					\
+	__sfr __at 0x9b volatile BYTE ##name_head_LSB; 					\
+	__sfr __at 0x9d volatile BYTE ##name_tail_MSB; 					\
+	__sfr __at 0x9e volatile BYTE ##name_tail_LSB;					\
+	__sfr __at 0x9e volatile BYTE ##name_tail_LSB;					\
+	BYTE name##_size;								\
+	__xdata BYTE name##_buffer[1<<size];						\
+	BOOL name##_init()								\
+	{										\
+		AUTOPTRSETUP = bmAPTR2INC | bmAPTR1INC | bmAPTREN;			\
+		LOADWORD(AUTOPTR1, &name##_buffer);					\
+		LOADWORD(AUTOPTR2, &name##_buffer);					\
+		return TRUE;								\
+	}										\
+	BOOL name##_push(BYTE data)							\
+	{										\
+		get_data();								\
+	}										\
+	BYTE name##_pop()								\
+	{										\
+		return_data();								\
+	}										\
+	BOOL name##_init();								\
+	BOOL name##_push(BYTE data);							\
+	BYTE name##_pop();
+
+static inline get_data()
+{
+	__asm
+	mov a,#0x45 							
+	mov dptr,#0xE67B							
+	movx @dptr,a
+	__endasm;
+}
+
+static inline return_data()
+{
+	__asm									
+	mov dptr,#0xE67C							
+	movx a,@dptr								
+	mov dpl,a								
+	__endasm;
+}		
+#endif

--- a/include/buffer/buffer.h
+++ b/include/buffer/buffer.h
@@ -62,7 +62,8 @@ __sfr __at 0x9e   tail_LSB;
 	}										\
 	BOOL name##_push(BYTE data)							\
 	{										\
-		__asm									\
+		printf("INside buffer makeowrd is %p",MAKEWORD(name##src,name##_offset));\
+		__asm\
 		mov a, _##name##count				\
 		cjne a,_##name##_sizeb,0002$			\
 		ret;							\
@@ -73,8 +74,11 @@ __sfr __at 0x9e   tail_LSB;
 		cjne a,_current_buffer,0001$			\
 		__endasm;										\
 		put_data();				\
+		__asm__("mov _" #name "_offset,_head_LSB");\
+		name##count++;\
 		if((&name##_buffer) + name##_sizeb == MAKEWORD(name##src,name##_offset))			\
-		{												\
+		{\
+			printf("INside");\
 			name##src = MSB(&name##_buffer);\
 			name##_offset = LSB(&name##_buffer);\
 			__asm\
@@ -90,9 +94,22 @@ __sfr __at 0x9e   tail_LSB;
 		mov _head_LSB,_##name##_offset			\
 		__endasm;								\
 		put_data();					\
+		__asm__("mov  _" #name    "_offset,_head_LSB");\
+		if((&name##_buffer) + name##_sizeb == MAKEWORD(name##src,name##_offset))			\
+		{\
+			printf("INside");\
+			name##src = MSB(&name##_buffer);\
+			name##_offset = LSB(&name##_buffer);\
+			__asm\
+			mov _head_MSB,_##name##src				\
+			mov _head_LSB,_##name##_offset		\
+			__endasm;\
+		}\
+		name##count++;					\
 	}										\
 	BYTE name##_pop()								\
 	{										\
+		name##count--;								\
 		return_data();								\
 	}										\
 	BOOL name##_init();								\

--- a/include/buffer/buffer.h
+++ b/include/buffer/buffer.h
@@ -21,16 +21,16 @@
 	type BYTE name##_buffer[1<<size];
 
 #define CREATE_BUFFER_AUTOPTR_SINGLE(name,size) 					\
-	__sfr __at 0x9a volatile BYTE ##name_head_MSB; 					\
-	__sfr __at 0x9b volatile BYTE ##name_head_LSB; 					\
-	__sfr __at 0x9d volatile BYTE ##name_tail_MSB; 					\
-	__sfr __at 0x9e volatile BYTE ##name_tail_LSB;					\
-	__sfr __at 0x9e volatile BYTE ##name_tail_LSB;					\
+	__sfr __at 0x9a   name##_head_MSB; 					\
+	__sfr __at 0x9b   name##_head_LSB; 					\
+	__sfr __at 0x9d   name##_tail_MSB; 					\
+	__sfr __at 0x9e   name##_tail_LSB;					\
+	__sfr __at 0x9e   name##_tail_LSB;					\
 	BYTE name##_size;								\
 	__xdata BYTE name##_buffer[1<<size];						\
 	BOOL name##_init()								\
 	{										\
-		AUTOPTRSETUP = bmAPTR2INC | bmAPTR1INC | bmAPTREN;			\
+		AUTOPTRSETUP =   bmAPTREN|bmAPTR1INC|bmAPTR2INC;			\
 		LOADWORD(AUTOPTR1, &name##_buffer);					\
 		LOADWORD(AUTOPTR2, &name##_buffer);					\
 		return TRUE;								\
@@ -47,21 +47,17 @@
 	BOOL name##_push(BYTE data);							\
 	BYTE name##_pop();
 
-static inline get_data()
+static inline void get_data()
 {
-	__asm
-	mov a,#0x45 							
-	mov dptr,#0xE67B							
-	movx @dptr,a
-	__endasm;
+	XAUTODAT1 = 0x45;
 }
 
-static inline return_data()
+static inline BYTE return_data()
 {
-	__asm									
-	mov dptr,#0xE67C							
-	movx a,@dptr								
-	mov dpl,a								
+	__asm
+	mov dptr,#0x3c00
+	movx a,@dptr
+	mov dpl,a
 	__endasm;
 }		
 #endif

--- a/include/buffer/buffer.h
+++ b/include/buffer/buffer.h
@@ -55,9 +55,8 @@ static inline void get_data()
 static inline BYTE return_data()
 {
 	__asm
-	mov dph,_buffer0_tail_MSB
-	mov dpl,_buffer0_tail_LSB
-	movx a,@dptr
+	mov	dptr,#_XAUTODAT2
+	movx	a,@dptr
 	mov dpl,a
 	__endasm;
 }		

--- a/include/fx2regs.h
+++ b/include/fx2regs.h
@@ -324,10 +324,10 @@ __sfr __at 0x98 SCON0;
          __sbit __at 0x98+7 SM0;
 __sfr __at 0x99 SBUF0;
 
-__sfr __at 0x9A AUTOPTRH1; 
-__sfr __at 0x9B AUTOPTRL1; 
-__sfr __at 0x9D AUTOPTRH2;
-__sfr __at 0x9E AUTOPTRL2; 
+__sfr __at 0x9A AUTOPTR1H; 
+__sfr __at 0x9B AUTOPTR1L; 
+__sfr __at 0x9D AUTOPTR2H;
+__sfr __at 0x9E AUTOPTR2L; 
 
 __sfr __at 0xA0 IOC;
          /*  IOC  */
@@ -640,5 +640,10 @@ __sfr __at 0xF8 EIP; // EIP Bit Values differ from Reg320
 #define bmIE4           bmBIT6
 #define bmI2CINT        bmBIT5
 #define bmUSBNT         bmBIT4
+
+/* AUTOPTRSETUP - Setup autopointer flags */
+#define bmAPTREN        bmBIT0
+#define bmAPTR1INC      bmBIT1
+#define bmAPTR2INC      bmBIT2
 
 #endif   /* FX2REGS_H */


### PR DESCRIPTION
This defines a robust and flexible buffer API which allows the example code to access the buffer functionality in a standard manner irrespective of how the device is actually implementing this functionality. 
