### PR TITLE
Improve initial experience on OSX

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,25 @@ You can also build the documentation if you have doxygen installed.
 
 You can copy the fw directory to your own directory and customize it as needed.
 
+** Firmware on OSX
+
+You will need `sdcc`, which can be obtained via Homebrew (http://brew.sh):
+
+> brew install sdcc
+
+Then, you can simply run `make' as per above.
+
+fx2load is needed to load the firmware on OSX; see examples/fx2. This is a
+Python package and can be built with setuptools (a virtualenv is highly
+recommended):
+
+> cd examples/fx2
+> python setup.py install
+
+You may need to install libusb for this; this can be done via Homebrew:
+
+> brew install libusb
+
 ** More custom firmware
 
 To use routines included with this library in your own firmware,

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,7 @@
-DIRS=	bulkloop debugdevice debugdevice_full_duplex eeprom i2c lights reset serial timers usbmon_c
+DIRS=	bulkloop debugdevice eeprom i2c lights reset serial timers usbmon_c
+ifneq ($(shell uname),Darwin)
+DIRS+=  debugdevice_full_duplex
+endif
      
 .PHONY: dirs $(DIRS) clean
      

--- a/examples/fx2/scripts/fx2load
+++ b/examples/fx2/scripts/fx2load
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2009 Ubixum, Inc. 
 #
@@ -22,7 +22,7 @@ import optparse
 
 parser=optparse.OptionParser (usage="Usage: %prog [options] bixfile")
 parser.add_option( "-v", "--vid", type='int', default=0x04b4,help='Vendor ID (0x04b4)')
-parser.add_option( "-p", '--pid', type='int', default=0x0082,help='Product Id (0x0082)')
+parser.add_option( "-p", '--pid', type='int', default=0x8613,help='Product Id (0x8613)')
 
 opts,args=parser.parse_args()
 

--- a/examples/fx2/setup.py
+++ b/examples/fx2/setup.py
@@ -4,7 +4,8 @@ fx2_mod = Extension (
  '_fx2',
  sources=['cpp/fx2.cpp', 'cpp/fx2.i'],
  swig_opts=['-c++'],
- include_dirs = ['/usr/include/python2.5'],
+ include_dirs = ['/usr/include/python2.5', '/usr/local/include'],
+ library_dirs = ['/usr/local/lib'],
  libraries = ['usb-1.0']
 )
 


### PR DESCRIPTION
It should now be possible to run `make' on OSX without significant issues.

I need to also update the README to point out the existence of the new `Makefile` variables that are very useful depending on how the developer's OSX environment is configured.
