### PR TITLE
Rework lights for FX2LP CY7C68013A mini boards

### DIFF
--- a/examples/bulkloop/bulkloop.c
+++ b/examples/bulkloop/bulkloop.c
@@ -96,7 +96,7 @@ void main() {
  printf ( "Done initializing stuff\n" );
 
  
- d3off();
+ d1off();
  
  while(TRUE) {
  
@@ -204,13 +204,13 @@ void sudav_isr() __interrupt SUDAV_ISR {
   CLEAR_SUDAV();
 }
 
-__bit on5;
+__bit on2;
 __xdata WORD sofct=0;
 void sof_isr () __interrupt SOF_ISR __using 1 {
     ++sofct;
     if(sofct==8000) { // about 8000 sof interrupts per second at high speed
-        on5=!on5;
-        if (on5) {d5on();} else {d5off();}
+        on2=!on2;
+        if (on2) {d2on();} else {d2off();}
         sofct=0;
     }
     CLEAR_SOF();

--- a/examples/debugdevice/debugdev.c
+++ b/examples/debugdevice/debugdev.c
@@ -95,7 +95,7 @@ void main()
 	printf ( "USB DEBUG: Done initializing stuff\n" );
 
 
-	d3off();
+	d1off();
 
 	while(TRUE) {
 
@@ -207,16 +207,16 @@ void sudav_isr() __interrupt SUDAV_ISR {
 	CLEAR_SUDAV();
 }
 
-__bit on5;
+__bit on2;
 __xdata WORD sofct=0;
 void sof_isr () __interrupt SOF_ISR __using 1
 {
 	if(++sofct==8000) { // about 8000 sof __interrupts per second at high speed
-		on5 = !on5;
-		if (on5) {
-			d5on();
+		on2 = !on2;
+		if (on2) {
+			d2on();
 		} else {
-			d5off();
+			d2off();
 		}
 		sofct=0;
 	}

--- a/examples/lights/lights.c
+++ b/examples/lights/lights.c
@@ -21,17 +21,22 @@
 #include <lights.h>
 #include <delay.h>
 
-volatile __xdata BYTE* bytes[] = { &D2ON, &D3ON, &D4ON, &D5ON, &D2OFF, &D3OFF, &D4OFF, &D5OFF };
-
 void main(void)
 {
-    volatile BYTE tmp;
-	BYTE cur=0;
+    BYTE n = 0;
 
-    // loop endlessly
-    for(;;) {
-       tmp=*bytes[cur];
-       delay(50);
-       cur = cur == 7 ? 0 : cur+1;
+    init_lights();
+    for (;;) {
+        if (n == 0) {
+            d1on();
+        } else if (n == 1) {
+            d2on();
+        } else if (n == 2) {
+            d1off();
+        } else {
+            d2off();
+        }
+        delay(250);
+        n = (n + 1) % 4;
     }
 }

--- a/examples/reset/reset.c
+++ b/examples/reset/reset.c
@@ -72,9 +72,10 @@ void main() {
  eeprom_write_local(LG_PROM, 0, IIC_SIZE, fx2_c0);
 
  
+ init_lights();
  while (1) {
     delay(1000);
-    if (on) {d5on();} else {d5off();}
+    if (on) {d1on();} else {d1off();}
     on = !on;    
  }
  

--- a/examples/serial/serial.c
+++ b/examples/serial/serial.c
@@ -70,7 +70,7 @@ void main(void)
 	TR1=1; // start timer 1
 	
 	
-	d5off(); // end init
+	d1off(); // end init
 	
 	while (1) {
 		char r=getchar();

--- a/examples/timers/timers.c
+++ b/examples/timers/timers.c
@@ -21,24 +21,24 @@
 #include <fx2ints.h>
 #include <lights.h>
 
+volatile __bit d1;
 volatile __bit d2;
 volatile __bit d3;
-volatile __bit d4;
 volatile __bit d5;
 
 void timer0_isr() __interrupt TF0_ISR {
+ d1 = !d1;
+ if (d1) { d1on(); } else { d1off(); }
+}
+
+void timer1_isr() __interrupt TF1_ISR {
  d2 = !d2;
  if (d2) { d2on(); } else { d2off(); }
 }
 
-void timer1_isr() __interrupt TF1_ISR {
- d3 = !d3;
- if (d3) { d3on(); } else { d3off(); }
-}
-
 void timer2_isr() __interrupt TF2_ISR {
- d4 = !d4;
- if (d4) { d4on(); } else { d4off(); }
+ d3 = !d3;
+ if (d3) { d1on(); d2on(); } else { d1off(); d2off(); }
 
  CLEAR_TIMER2(); // This one is not done automatically!
 }
@@ -66,13 +66,7 @@ void main(void)
     TR1=1; // start t1 
     TR2=1; // start t2
 
-    // and blink d5
     while (TRUE) {
-        ++counter;
-        if (!counter) {
-            d5 = !d5;
-            if (d5) { d5off(); } else { d5on(); }
-        }
     }
 }
 

--- a/include/lights.h
+++ b/include/lights.h
@@ -23,74 +23,12 @@
 
 #include "fx2types.h"
 
-#ifndef FX1
-// FX2 Dev board lights
-#define D2ONH #0x88 // assembly high byte of light addr 
-#define D2OFFH #0x80 
-#define D3ONH #0x98 
-#define D3OFFH #0x90 
-#define D4ONH #0xA8 
-#define D4OFFH #0xA0 
-#define D5ONH #0xB8 
-#define D5OFFH #0xB0 
-volatile __xdata __at 0x8800 BYTE D2ON;
-volatile __xdata __at 0x8000 BYTE D2OFF;
-volatile __xdata __at 0x9800 BYTE D3ON;
-volatile __xdata __at 0x9000 BYTE D3OFF;
-volatile __xdata __at 0xA800 BYTE D4ON;
-volatile __xdata __at 0xA000 BYTE D4OFF;
-volatile __xdata __at 0xB800 BYTE D5ON;
-volatile __xdata __at 0xB000 BYTE D5OFF;
-#else
-// FX1 dev board lights
-#define D2ONH #0x80 // assembly high byte of light addr 
-#define D2OFFH #0x81 
-#define D3ONH #0x90 
-#define D3OFFH #0x91 
-#define D4ONH #0xA0 
-#define D4OFFH #0xA1 
-#define D5ONH #0xB0 
-#define D5OFFH #0xB1 
-volatile __xdata __at 0x8000 BYTE D2ON;
-volatile __xdata __at 0x8100 BYTE D2OFF;
-volatile __xdata __at 0x9000 BYTE D3ON;
-volatile __xdata __at 0x9100 BYTE D3OFF;
-volatile __xdata __at 0xA000 BYTE D4ON;
-volatile __xdata __at 0xA100 BYTE D4OFF;
-volatile __xdata __at 0xB000 BYTE D5ON;
-volatile __xdata __at 0xB100 BYTE D5OFF;
-#endif
+#define init_lights() IFCONFIG &= ~3; PORTACFG = 0x00
 
-/**
- * Easier to use macros defined below 
-**/
-#define activate_light(LIGHT_ADDR) __asm \
- mov __XPAGE, LIGHT_ADDR \
- __endasm; __asm \
- movx a, @r0 \
-__endasm \
+#define d1on() OEA |= 0x01; IOA &= ~0x01
+#define d2on() OEA |= 0x02; IOA &= ~0x02
 
-/**
- *  Easy to make lights blink with these macros:
- *  \code
- *      WORD ct=0;
- *      BOOL on=FALSE;
- *      while (TRUE) {
- *          if (!ct) {
- *              on=!on;
- *              if (on) d2on(); else d2off();
- *          }
- *          ++ct;
- *      }
- *  \endcode
- **/
-#define d2on() activate_light(D2ONH)
-#define d2off() activate_light(D2OFFH)
-#define d3on() activate_light(D3ONH)
-#define d3off() activate_light(D3OFFH)
-#define d4on() activate_light(D4ONH)
-#define d4off() activate_light(D4OFFH)
-#define d5on() activate_light(D5ONH)
-#define d5off() activate_light(D5OFFH)
+#define d1off() OEA |= 0x01; IOA |= 0x01
+#define d2off() OEA |= 0x02; IOA |= 0x02
 
 #endif


### PR DESCRIPTION
This allows the smaller boards (e.g. https://sigrok.org/wiki/Lcsoft_Mini_Board) with 56-pin chips to run the examples.

The downside is that the 100+ pin chips that can drive all five previously-supported LEDs are now unable to do so. This could be somewhat abstracted via the preprocessor and defines passed via the `Makefile`, if that will be a problem for future usage of fx2lib.
